### PR TITLE
Add support for Symfony 2.7 and later

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -1,7 +1,7 @@
 {
   "name" : "symfony",
   "display_name" : "Symfony",
-  "version" : "1.0.3",
+  "version" : "1.0.4",
   "type": ["zray", "route"],
   "logo": "logo.png",
   "eula": "LICENSE.txt",

--- a/zray/zray.php
+++ b/zray/zray.php
@@ -19,11 +19,12 @@ class Symfony {
 
 	public function eventDispatchExit($context, &$storage) {
 		if(!$context['functionArgs'][1]) { return; }
+		$eventname = $context['functionArgs'][0];
 		$event = $context['functionArgs'][1];
 		$storage['events'][] = array(	
-						'name' => $event->getName(),
+						'name' => $eventname,
 						'type' => get_class($event),
-						'dispatcher' => get_class($event->getDispatcher()),
+						'dispatcher' => get_class($context['this']),
 						'propagation stopped' => $event->isPropagationStopped(),
 						);
 	}

--- a/zray/zray.php
+++ b/zray/zray.php
@@ -180,15 +180,19 @@ class Symfony {
 	
 	public function logAddRecordExit($context, &$storage) {
 		static $logCount = 0;
+		$levelnames = array (
+			100 => 'Debug', 200 => 'Info', 250 => 'Notice', 300 => 'Warning', 400 => 'Error',
+			500 => 'Critical', 550 => 'Alert', 600 => 'Emergency'
+		);
 
-		$record = $context['locals']['record'];
-		
+		$level = $context['functionArgs'][0];
+		$message = $context['functionArgs'][1];
 
 		$storage['Monolog'][] = array(
 						'#' => ++$logCount,
-						'message' => $record['message'],
-						'level' => $record['level_name'],
-						'channel' => $record['channel'],
+						'message' => $message,
+						'level' => isset ($levelnames[$level]) ? $levelnames[$level] : $level,
+						'channel' => $context['this']->getName(),
 					);
 	}
 }


### PR DESCRIPTION
In Symfony 2.7, the getName() and getDispatcher() calls were deprecated.  These deprecated calls were later removed (I believe in Symfony 3.0)

This causes Z-Ray to break with newer versions of Symfony.  The recommended way (per the Symfony 2.3 to Symfony 2.7) guide is to instead get them in the listener call.  It's also possible to get the name from the parameter passed to dispatch(), and the dispatcher from the context.

Doing so fixes later versions of Symfony and should be backwards compatible.